### PR TITLE
Add Native Image plugin and doc

### DIFF
--- a/doc/native-image.adoc
+++ b/doc/native-image.adoc
@@ -1,0 +1,24 @@
+Native Image
+------------
+
+https://www.graalvm.org/reference-manual/native-image/[Native image] allows to run tangler without Clojure or JVM installation. The product of the native image is AOT-compiled binary.
+
+Build Requirements
+^^^^^^^^^^^^^^^^^^
+* GraalVM 20.2.0
+* Clojure at least 1.10.2-alpha1
+
+Build
+^^^^^
+To build the native image:
+
+* Make sure Build Requirements are satisfied
+* Install native-image
+```
+gu install native-image
+```
+* Run lein
+```
+lein native-image
+```
+

--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,19 @@
   :url "http://github.com/wlad031/tagler"
   :license {:name "DO WHAT THE FUCK YOU WANT TO PUBLIC LICENSE Version 2"
             :url  "http://www.wtfpl.net/"}
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[org.clojure/clojure "1.10.2-alpha2"]
                  [org.clojure/tools.cli "1.0.194"]
                  [com.taoensso/timbre "4.10.0"]]
   :repl-options {:init-ns tangler.core}
   :plugins [[lein-cljfmt "0.7.0"]
-            [lein-kibit "0.1.8"]]
+            [lein-kibit "0.1.8"]
+            [io.taylorwood/lein-native-image "0.3.1"]]
+  :native-image {:name "tangler"
+                 :opts ["--verbose" 
+                        "--no-fallback" 
+                        "--initialize-at-build-time" 
+                        "--report-unsupported-elements-at-runtime"]} 
+  :profiles {:native-image {
+                      :dependencies [[borkdude/clj-reflector-graal-java11-fix "0.0.1-graalvm-20.2.0"]]
+                      :jvm-opts ["-Dclojure.compiler.direct-linking=true"]}}
   :main tangler.core)


### PR DESCRIPTION
Native image allows running `tangler` without having Clojure or JVM installed