### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -1,0 +1,23 @@
+name: Clojure CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install dependencies
+      run: lein deps
+    - name: Run tests
+      run: lein test
+    - name: lint
+      uses: DeLaGuardo/clojure-lint-action@master
+      with:
+        clj-kondo-args: --lint src
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  release-jar:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set env
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:11})
+      - name: Install dependencies
+        run: lein deps
+      - name: Build JAR
+        run: lein uberjar
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: target/tangler-${{ env.RELEASE_VERSION }}-standalone.jar
+          draft: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-native:
+    strategy:
+      matrix:
+        os:
+          - name: linux
+            image: ubuntu-latest
+          - name: macos
+            image: macOS-latest
+#          - name: windows
+#            image: windows-latest
+    runs-on: ${{ matrix.os.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set env
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:11})
+      - name: Install Clojure toolchain
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          lein: 2.9.4
+      - name: Install dependencies
+        run: lein deps
+      - name: Install Graal
+        uses: DeLaGuardo/setup-graalvm@3
+        with:
+          graalvm-version: '20.2.0.java11'
+      - name: Install Native Image
+        run: gu install native-image
+      - name: Build Native Image
+        run: lein native-image
+      - name: Package
+        run: sudo tar -czf tangler-x86_64-${{ matrix.os.name }}.tar.gz target/tangler
+      - name: Publish release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: tangler-x86_64-${{ matrix.os.name }}.tar.gz
+          draft: true
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+


### PR DESCRIPTION
Add Github Actions:

- For master pushes and PRs to master: run tests and linter
- For releases - build uber jar and native image (for linux and macos)

Release workflow will create a **draft** release with artifacts attached and no body. As it is a draft, it can be edited to add title and description before publishing. Release workflow is triggered whenever commit with tag `v*.*.*` is pushed.